### PR TITLE
MBS-10508: persist graderinfo in aitext + show during manual grading

### DIFF
--- a/edit_aitext_form.php
+++ b/edit_aitext_form.php
@@ -262,6 +262,20 @@ class qtype_aitext_edit_form extends question_edit_form {
             'format' => $question->options->responsetemplateformat,
         ];
 
+        $draftid = file_get_submitted_draft_itemid('graderinfo');
+        $question->graderinfo = [];
+        $question->graderinfo['text'] = file_prepare_draft_area(
+            $draftid,
+            $this->context->id,
+            'qtype_aitext',
+            'graderinfo',
+            !empty($question->id) ? (int) $question->id : null,
+            $this->fileoptions,
+            $question->options->graderinfo
+        );
+        $question->graderinfo['format'] = $question->options->graderinfoformat;
+        $question->graderinfo['itemid'] = $draftid;
+
         return $question;
     }
 

--- a/questiontype.php
+++ b/questiontype.php
@@ -133,13 +133,11 @@ class qtype_aitext extends question_type {
         $options->maxwordlimit = isset($formdata->maxwordenabled) ? $formdata->maxwordlimit : null;
 
         $options->maxbytes = $formdata->maxbytes ?? 0;
-        if (is_array($formdata->graderinfo)) {
+        if (!is_array($formdata->graderinfo)) {
             $formdata->graderinfo = [
-                'text' => '',
+                'text' => (string) $formdata->graderinfo,
                 'format' => FORMAT_HTML,
             ];
-            $options->responsetemplate = $formdata->responsetemplate['text'];
-            $options->responsetemplateformat = $formdata->responsetemplate['format'];
         }
 
         $options->graderinfo = $this->import_or_save_files(

--- a/renderer.php
+++ b/renderer.php
@@ -190,6 +190,33 @@ class qtype_aitext_renderer extends qtype_renderer {
     }
 
     /**
+     * Show grader information above the manual comment field when grading.
+     *
+     * @param question_attempt $qa
+     * @param question_display_options $options
+     * @return string
+     */
+    public function manual_comment(question_attempt $qa, question_display_options $options) {
+        if ($options->manualcomment != question_display_options::EDITABLE) {
+            return '';
+        }
+
+        $question = $qa->get_question();
+        return html_writer::nonempty_tag(
+            'div',
+            $question->format_text(
+                $question->graderinfo,
+                $question->graderinfoformat,
+                $qa,
+                'qtype_aitext',
+                'graderinfo',
+                $question->id
+            ),
+            ['class' => 'graderinfo']
+        );
+    }
+
+    /**
      * Displays any attached files when the question is in read-only mode.
      * @param question_attempt $qa the question attempt to display.
      * @param question_display_options $options controls what should and should


### PR DESCRIPTION
Fixes #51:
  - Fixes graderinfo not being saved for qtype_aitext.
  - Prepares graderinfo draft area in the edit form (aligned with qtype_essay).
  - Displays graderinfo above the manual comment field during manual grading.

Testing-Instructions:
  - Create an AI Text question with “Grader information”, save, re-open -> text persists.
  - Attempt the question, open manual grading (“Make comment or override mark”) -> graderinfo shows above the comment area.
  - Optional: phpunit component test.