### PR TITLE
MBS-10618: harden process feedback

### DIFF
--- a/tests/question_test.php
+++ b/tests/question_test.php
@@ -437,7 +437,25 @@ final class question_test extends \advanced_testcase {
                     'wäre korrekt). Punkte: 1/1.',
                 'expectedmathjaxapplied' => true,
                 'expectedmarks' => 1,
-            ]
+            ],
+            [
+                'json' => '{"feedback":"Richtig! Deine Eingabe \\(3 \cdot 7\\) ist gültig (auch \\(7 \cdot 3\\) ' .
+                    'wäre korrekt). Punkte: 1/1.","marks":1}',
+                'exceptionexpected' => false,
+                'expectedfeedback' => 'Richtig! Deine Eingabe \\\\(3 \\\\cdot 7\\\\) ist gültig (auch \\\\(7 \\\\cdot 3\\\\) ' .
+                    'wäre korrekt). Punkte: 1/1.',
+                'expectedmathjaxapplied' => true,
+                'expectedmarks' => 1,
+            ],
+            [
+                'json' => '{"feedback":"Richtig! Deine Eingabe \\\\(3 \cdot 7\\\\) ist gültig (auch \\\\(7 \cdot 3\\\\) ' .
+                    'wäre korrekt). Punkte: 1/1.","marks":1}',
+                'exceptionexpected' => false,
+                'expectedfeedback' => 'Richtig! Deine Eingabe \\\\(3 \\\\cdot 7\\\\) ist gültig (auch \\\\(7 \\\\cdot 3\\\\) ' .
+                    'wäre korrekt). Punkte: 1/1.',
+                'expectedmathjaxapplied' => true,
+                'expectedmarks' => 1,
+            ],
             // @codingStandardsIgnoreEnd
         ];
     }


### PR DESCRIPTION
Hey Marcus, 

we found, that when the LLM reponse is valid json, the parsing fails in some cases, when the json contains already 4 backslashes before "(" in an Mathjax expression. 

Here is my fix. @PhMemmel maybe you are able to review this too?

Cheers, Andi