### PR TITLE
Fix issue #72: AI disclaimer is not translated correctly

### DIFF
--- a/question.php
+++ b/question.php
@@ -535,7 +535,7 @@ class qtype_aitext_question extends question_graded_automatically_with_countback
         $cache = cache::make('qtype_aitext', 'stringdata');
         if (($translation = $cache->get(current_language() . '_' . $text)) === false) {
             $prompt = 'translate "' . $text . '" into ' . current_language() .
-                    'Only return the exact text, do not wrap it in other text.';
+                    '. Only return the exact text, do not wrap it in other text.';
             $translation = $this->perform_request($prompt, 'translate');
             $translation = trim($translation, '"');
             $cache->set(current_language() . '_' . $text, $translation);


### PR DESCRIPTION
It appears that the prompt given for translation was not joined correctly, creating something like this: translate "some text" into  etOnly return the exact text, do not wrap it in other text.

This PR fixes it to instead use: translate "some text" into  et. Only return the exact text, do not wrap it in other text.