### PR TITLE
Sanitize AI prompt before output to prevent XSS

### DIFF
--- a/renderer.php
+++ b/renderer.php
@@ -176,6 +176,12 @@ class qtype_aitext_renderer extends qtype_renderer {
 
                 $prompt = $qa->get_last_qt_var('-aiprompt');
 
+                // Clean the prompt so no script/JS can be injected, while keeping safe HTML.
+                $prompt = format_text($prompt, FORMAT_HTML, [
+                    'context' => $options->context ?? $this->page->context,
+                    'noclean' => false,
+                ]);
+
                 $showprompt  = '<br /><button id="showprompt" class="rounded">';
                 $showprompt .= get_string('showprompt', 'qtype_aitext') . '</button>';
                 $showprompt .= '<div id="fullprompt" class="hidden">' . $prompt . '</div>';


### PR DESCRIPTION
The feedback() renderer inserted the raw -aiprompt qt_var into the page HTML, allowing script injection. Run it through format_text(FORMAT_HTML, noclean=false) so clean_text() strips <script> tags, event handlers and javascript: URLs while keeping safe markup.

This issue was highlighted by MDLShield (https://mdlshield.com). 