### PR TITLE
Delete sample responses when question is deleted

### DIFF
--- a/questiontype.php
+++ b/questiontype.php
@@ -212,7 +212,7 @@ class qtype_aitext extends question_type {
      */
     public function delete_question($questionid, $contextid) {
         global $DB;
-
+        $DB->delete_records('qtype_aitext_sampleresponses', ['question' => $questionid]);
         $DB->delete_records('qtype_aitext', ['questionid' => $questionid]);
         parent::delete_question($questionid, $contextid);
     }

--- a/tests/question_type_test.php
+++ b/tests/question_type_test.php
@@ -111,4 +111,39 @@ final class question_type_test extends \advanced_testcase {
         $q = $this->get_test_question_data();
         $this->assertEquals([], $this->qtype->get_possible_responses($q));
     }
+
+    /**
+     * Deleting a question must also delete its sample responses so no orphan
+     * rows are left behind in qtype_aitext_sampleresponses.
+     *
+     * @covers ::delete_question()
+     *
+     * @return void
+     */
+    public function test_delete_question_removes_sampleresponses(): void {
+        global $DB;
+        $this->resetAfterTest();
+        $this->setAdminUser();
+
+        $generator = $this->getDataGenerator()->get_plugin_generator('core_question');
+        $category = $generator->create_question_category();
+        // The 'editor' fixture ships one sample response ('response1').
+        $question = $generator->create_question('aitext', 'editor', ['category' => $category->id]);
+
+        // Sanity check: the options row and one sample response row exist.
+        $this->assertTrue($DB->record_exists('qtype_aitext', ['questionid' => $question->id]));
+        $this->assertEquals(
+            1,
+            $DB->count_records('qtype_aitext_sampleresponses', ['question' => $question->id])
+        );
+
+        $this->qtype->delete_question($question->id, $category->contextid);
+
+        // Both the options row and the sample response rows must be gone.
+        $this->assertFalse($DB->record_exists('qtype_aitext', ['questionid' => $question->id]));
+        $this->assertEquals(
+            0,
+            $DB->count_records('qtype_aitext_sampleresponses', ['question' => $question->id])
+        );
+    }
 }


### PR DESCRIPTION
delete_question now removes rows from qtype_aitext_sampleresponses keyed by questionid, matching how they are inserted, read and backed up. The previous attempt keyed on the qtype_aitext row id and left orphan rows behind. Adds a PHPUnit test covering the cascade delete.