### PR TITLE
Fix #72: translate disclaimer into current language, not a random one

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,8 @@ This Moodle question type accepts free text which is then evaluated by a remote 
 It is being used with teachers in Universities around
 the world including in Germany, Japan, Isreal, and Turkey to my knowledge
 
-It requires either a paid for ChatGPT api account which will give access to ChatGPT4 or
-other Large Language Model such as Ollama or https://groq.com.
-ct
+It requires access to an external Large Language Model with an OpenAI API compatible interface, such as ChatGPT or Ollama.
+
 
 Additional documentation can be found here https://github.com/marcusgreen/moodle-qtype_aitext/wiki
 

--- a/changelog.md
+++ b/changelog.md
@@ -6,7 +6,7 @@ Sample responses are now XML-escaped on export. Any &, < or > in the sample resp
 
 Sample responses are deleted when the question they belong to is deleted, rather than being left orphaned in the database.
 
-The AI prompt shown by the "Show prompt" button when previewing a question is now sanitized before output. The renderer previously inserted the raw prompt straight into the page HTML, so script tags, event handlers or javascript: URLs held in the prompt would execute in the previewer's browser. It is now passed through format_text() with cleaning enabled, which strips those while leaving safe markup intact.
+The AI prompt shown by the "Show prompt" button when previewing a question is now sanitized before output. The renderer previously inserted the raw prompt straight into the page HTML, so script tags, event handlers or javascript: URLs held in the prompt would execute in the previewer's browser. It is now passed through format_text() with cleaning enabled, which strips those while leaving safe markup intact. Thanks to Paola Maneggia for feedback on this release and much other work.
 
 ## Release 2.02 Apr 2026
 

--- a/question.php
+++ b/question.php
@@ -532,10 +532,14 @@ class qtype_aitext_question extends question_graded_automatically_with_countback
             return $text;
         }
 
+        // Use the full language name (e.g. "Eesti" for et) rather than the ISO code, because LLMs do not
+        // reliably map two-letter codes to languages and will otherwise translate into an arbitrary language.
+        $languagename = get_string('thislanguage', 'langconfig');
+
         $cache = cache::make('qtype_aitext', 'stringdata');
         if (($translation = $cache->get(current_language() . '_' . $text)) === false) {
-            $prompt = 'translate "' . $text . '" into ' . current_language() .
-                    'Only return the exact text, do not wrap it in other text.';
+            $prompt = 'translate "' . $text . '" into ' . $languagename .
+                    '. Only return the exact text, do not wrap it in other text.';
             $translation = $this->perform_request($prompt, 'translate');
             $translation = trim($translation, '"');
             $cache->set(current_language() . '_' . $text, $translation);

--- a/tests/question_test.php
+++ b/tests/question_test.php
@@ -28,6 +28,7 @@ global $CFG;
 require_once($CFG->dirroot . '/question/engine/tests/helpers.php');
 require_once($CFG->dirroot . '/question/type/aitext/tests/helper.php');
 require_once($CFG->dirroot . '/question/type/aitext/questiontype.php');
+require_once($CFG->dirroot . '/question/type/aitext/question.php');
 require_once($CFG->dirroot . '/mod/quiz/locallib.php');
 
 use qtype_aitext_test_helper;
@@ -750,5 +751,87 @@ final class question_test extends \advanced_testcase {
         // Assert that the resolved context is not returning the user context, but the qbank context instead.
         $this->assertNotEquals($usercontext->id, $resolvedcontextid);
         $this->assertEquals($qbankcontext->id, $resolvedcontextid);
+    }
+
+    /**
+     * Invoke the protected llm_translate() on a mock and return the prompt it sends to the LLM.
+     *
+     * The perform_request() call (which would hit an external LLM) is mocked so the test can
+     * capture the prompt string that llm_translate() builds, without any network access.
+     *
+     * @param string $text the text passed to llm_translate().
+     * @return string the prompt string handed to perform_request().
+     */
+    protected function capture_translate_prompt(string $text): string {
+        $captured = '';
+        $mock = $this->getMockBuilder(\qtype_aitext_question::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['perform_request'])
+            ->getMock();
+        $mock->method('perform_request')->willReturnCallback(
+            function (string $prompt, string $purpose = 'feedback') use (&$captured): string {
+                $captured = $prompt;
+                return '"TRANSLATED"';
+            }
+        );
+
+        $method = new \ReflectionMethod(\qtype_aitext_question::class, 'llm_translate');
+        $method->setAccessible(true);
+        $method->invoke($mock, $text);
+
+        return $captured;
+    }
+
+    /**
+     * Issue #72: the translation prompt must name the target language, not the ISO code.
+     *
+     * Reproduces the bug where current_language() ('et') was placed in the prompt verbatim
+     * ('... into et'), which LLMs do not reliably map to a language, causing the disclaimer to
+     * be returned in an arbitrary language (Dutch, Malay, ...). After the fix the prompt must
+     * contain the resolved language name from langconfig instead of the bare code.
+     *
+     * @covers ::llm_translate()
+     */
+    public function test_llm_translate_prompt_uses_language_name(): void {
+        global $SESSION;
+        $this->resetAfterTest();
+        set_config('translatepostfix', 1, 'qtype_aitext');
+        // Force a non-English language. Set forcelang directly rather than via
+        // force_current_language(), which silently ignores languages whose pack is not installed.
+        $SESSION->forcelang = 'et';
+
+        $prompt = $this->capture_translate_prompt('Response provided by an AI system');
+
+        // The resolved language name (e.g. "Eesti", or the langconfig fallback) must appear.
+        $languagename = get_string('thislanguage', 'langconfig');
+        $this->assertStringContainsString('into ' . $languagename, $prompt);
+
+        // The bare two-letter code must NOT be used as the translation target.
+        $this->assertStringNotContainsString('into et', $prompt);
+    }
+
+    /**
+     * Issue #72: the language and the trailing instruction must be separated.
+     *
+     * Reproduces the concatenation bug: current_language() . 'Only return...' produced
+     * '... into etOnly return the exact text', gluing the language token to the next word.
+     * After the fix a separator must sit between the language name and "Only return".
+     *
+     * @covers ::llm_translate()
+     */
+    public function test_llm_translate_prompt_separates_instruction(): void {
+        global $SESSION;
+        $this->resetAfterTest();
+        set_config('translatepostfix', 1, 'qtype_aitext');
+        // Force a non-English language. Set forcelang directly rather than via
+        // force_current_language(), which silently ignores languages whose pack is not installed.
+        $SESSION->forcelang = 'et';
+
+        $prompt = $this->capture_translate_prompt('Response provided by an AI system');
+
+        $languagename = get_string('thislanguage', 'langconfig');
+        // The instruction must be delimited, not glued to the language name ("EestiOnly").
+        $this->assertStringNotContainsString($languagename . 'Only', $prompt);
+        $this->assertStringContainsString('. Only return the exact text', $prompt);
     }
 }


### PR DESCRIPTION
Fixes #72

## Problem
The AI disclaimer appended after feedback appeared in random languages (Dutch, Malay) instead of the user's language (e.g. Estonian).

## Root cause
`llm_translate()` (`question.php`) built the translation prompt from the two-letter ISO code returned by `current_language()`:

```
translate "Response provided by an AI system" into etOnly return the exact text, do not wrap it in other text.
```

Two defects:
1. **ISO code, not language name** — LLMs do not reliably map `et` to a language, so they return an arbitrary one.
2. **Missing separator** — `current_language() . 'Only return...'` glued the token to the next word (`etOnly`).

## Fix
Resolve the code to the language name via `get_string('thislanguage', 'langconfig')` (e.g. `et` → `Eesti`) and add a separator before the instruction.

## Tests
Two PHPUnit tests capture the generated prompt and assert it names the language and delimits the instruction. Both fail on the old code and pass after the fix.